### PR TITLE
Enable /rfilter

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -56,3 +56,6 @@ Version 1.4.0
 	- Cleaned up some of the server listings
 	- Reflect changes in the datacentre merges
 	- New colour scheme (feedback wanted for this)
+
+Version 1.5.2
+	- Slash command '/rfilter' to remove groups from outside your region.

--- a/RegionFilter.toc
+++ b/RegionFilter.toc
@@ -1,7 +1,7 @@
 ## Interface: 90105
 ## Title: Region Filter
 ## Notes: Tags groups in the native LFG search if they are from your server and data-centre
-## Version: 1.5.0
+## Version: 1.5.2
 
 utils.lua
 servers.lua


### PR DESCRIPTION
Enabled /rfilter

Issues:
1. after clicking refresh, new entries will not contain leader information. Open/close to get filter working (hit 'i' twice)
2. You will only get 100 results back from API. Refresh often to find more groups for smaller regions (OCE)